### PR TITLE
replaced unzip version with 6.0-21+deb9u2

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -7,7 +7,7 @@ FROM debian:stretch-20190506-slim as terraform
 ARG TERRAFORM_VERSION
 RUN apt-get update
 RUN apt-get install -y curl=7.52.1-5+deb9u9
-RUN apt-get install -y unzip=6.0-21+deb9u1
+RUN apt-get install -y unzip=6.0-21+deb9u2
 RUN apt-get install -y gnupg=2.1.18-8~deb9u4
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Building the image fails with the current defined version of `unzip=6.0-21+deb9u1`. This version has been replaced with the latest version.

```
Step 7/30 : RUN apt-get install -y unzip=6.0-21+deb9u1
 ---> Running in cde028776d69
Reading package lists...
Building dependency tree...
Reading state information...
E: Version '6.0-21+deb9u1' for 'unzip' was not found
The command '/bin/sh -c apt-get install -y unzip=6.0-21+deb9u1' returned a non-zero code: 100
```