### PR TITLE
upgrade curl/python versions for successful build

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -6,7 +6,7 @@ ARG TERRAFORM_VERSION=0.12.2
 FROM alpine:3.9.4 as terraform
 ARG TERRAFORM_VERSION
 RUN apk update
-RUN apk add curl=7.64.0-r2
+RUN apk add curl=7.64.0-r3
 RUN apk add unzip=6.0-r4
 RUN apk add gnupg=2.2.12-r0
 RUN curl -Os https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS
@@ -22,8 +22,8 @@ RUN unzip -j terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 FROM alpine:3.9.4 as aws-cli
 ARG AWS_CLI_VERSION
 RUN apk update
-RUN apk add python3=3.6.8-r2
-RUN apk add python3-dev=3.6.8-r2
+RUN apk add python3=3.6.9-r2
+RUN apk add python3-dev=3.6.9-r2
 RUN apk add py3-setuptools=40.6.3-r0
 RUN pip3 install awscli==${AWS_CLI_VERSION}
 
@@ -34,7 +34,7 @@ RUN apk --no-cache add \
   ca-certificates=20190108-r0 \
   groff=1.22.3-r2 \
   jq=1.6-r0 \
-  python3=3.6.8-r2 \
+  python3=3.6.9-r2 \
   && ln -s /usr/bin/python3 /usr/bin/python
 COPY --from=terraform /terraform /usr/bin/terraform
 COPY --from=aws-cli /usr/bin/aws* /usr/bin/


### PR DESCRIPTION
Updated curl to 7.64.0-r3 and python to 3.6.9-r2 so the docker build would complete.